### PR TITLE
Disable zoom in mobile

### DIFF
--- a/assets/scripts.js.twig
+++ b/assets/scripts.js.twig
@@ -14,9 +14,9 @@ $(document).ready(function() {
   }
 
   {% if settings.enable_product_image_zoom %}
-  if ($('#zoom').size() > 0) {
-    $("#zoom").elevateZoom({ responsive: true, cursor: 'pointer' });
-  }
+    if ($('#zoom').size() > 0 && $(window).width() > 767) {
+      $("#zoom").elevateZoom({ responsive: true, cursor: 'pointer' });
+    }
   {% endif %}
 
   if ($('.product__carousel div').size() > 0) {


### PR DESCRIPTION
@joecohens @arturock 

Sobre el caso de la tienda que tiene problemas con el zoom:
https://sobremesa.kometia.com/productos/carnes-frias-quesos-y-vino-2-personas
https://app.intercom.com/a/apps/nxstrkel/inbox/inbox/1955593/conversations/21927900007420

Jurban está usando este plugin:
https://www.elevateweb.co.uk/image-zoom/ El cual no tiene eventos touch para desactivarlo en mobile.

Creo que todos los demás temas tienen este:
http://www.jacklmoore.com/zoom/

Que si tiene eventos.
Una solución es desactivar el zoom en mobile. La otra es cambiar el plugin.

La tienda sobremesa tiene plan básico y no puedo editar su html. Si Arturo me ayuda cambiando temporalmente el plan podría quitarlo solo en su tienda.
